### PR TITLE
Selection fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MiMiCPy
 MiMiCPy is the python library for preparing and executing QM/MM simulations with the MiMiC CPMD/Gromacs interface developed at Forschungszentrum Juelich and EPFL. [1] For more details on compiling the MiMiC source code, please refer [2].
 
-MiMiCPy is primarily a python wrapper around MiMiC for easy running of simulations, and preparing input files with support for custom selection language and integration with molecular visualization software packages like PyMOL. A collection of command line tools based on top of the library is also being being developed.
+MiMiCPy is primarily a python wrapper around MiMiC for efficient running of simulations, and preparing input files with support for custom selection language and integration with molecular visualization software packages like PyMOL. It also includes the MiMiCPy CLI tools, a collection of command line tools to the run the core functionalities of the library through the command line.
 
 ## Installation
 MiMiCPy is not available on pip/conda yet. To install run the following command in the terminal:

--- a/mimicpy/cmdline.py
+++ b/mimicpy/cmdline.py
@@ -1,0 +1,52 @@
+#import mimicpy
+import argparse
+import sys
+
+class MiMiCPyParser(argparse.ArgumentParser):
+    def __init__(self):
+        super().__init__(usage='MiMiCPy CLI Program')
+        
+    def error(self, message):
+        print("NOOOO!!!")
+
+def interact():
+    command = input('Please enter the selection below. Type help to get help message.\n>  ')
+    command = command.split()
+    prefix = command[0].lower()
+    if prefix == 'q'or prefix == 'quit':
+        return False
+    elif prefix == 'add':
+        return True
+    elif prefix == 'del':
+        return True
+    elif prefix == 'clear':
+        return True
+    elif prefix == 'help' or prefix == 'h':
+        print("Following commands are understood:\n\n"
+              "- add <selection>\n\tAdd atoms (given by the selection) to the QM region\n\n"
+              "- del <selection>\n\tDelete atoms (given by selection) from the QM region\n\n"
+              "- clear\n\tClear all atoms from the QM region to start over\n\n"
+              "- quit or q\n\tGenerate the CPMD input and Gromacs index files from selected atoms, and quit.\n\n"
+              "- help or h\n\tShow this help message.\n\n"
+              "A keyboard interrupt will cause an immediate termination. "
+              "Also, for more information on the selection langauge please refer to the docs.\n")
+    else:
+        print("Command not understood! Type help to get a list of accepted commands.\n")
+        return True
+
+if __name__ == '__main__':
+    
+    parser = MiMiCPyParser()
+    parser.add_argument("subprogram", help="Subprogram to be called", type=str)
+    
+    args = parser.parse_args()
+    
+    if args.subprogram != 'prepqm':
+        sys.exit(0)
+    while True:
+        try:
+            ret = interact()
+        except (KeyboardInterrupt, EOFError):
+            print("\nExiting without saving..")
+            break
+        if ret == False: break

--- a/mimicpy/cmdline.py
+++ b/mimicpy/cmdline.py
@@ -1,52 +1,215 @@
-#import mimicpy
-import argparse
+import mimicpy
 import sys
+import time
+import itertools
+import threading
 
-class MiMiCPyParser(argparse.ArgumentParser):
-    def __init__(self):
-        super().__init__(usage='MiMiCPy CLI Program')
+empty_status = {'prepMM': '', 'prepQM': '', 'run': ['']}
+mimicpy.setLogger(1)
+
+class Loader:
+    def __init__(self, message):
+        self.done = False
+        self.message = message
+        t = threading.Thread(target=self.__animate)
+        t.start()
+
+    def __animate(self):
+        for c in itertools.cycle(['|', '/', '-', '\\']):
+            if self.done:
+                break
+            sys.stdout.write(f'\r{self.message}  ' + c)
+            sys.stdout.flush()
+            time.sleep(0.1)
+    
+    def close(self):
+        self.done = True
+        print('Done')
         
-    def error(self, message):
-        print("NOOOO!!!")
+class MiMiCPyParser():
+    
+    subprograms = {'getmpt': 'Generate MiMiCPy topology from Gromacs topology', 
+               'prepqm': 'Prepare QM region by generating the CPMD input and Gromacs index files',
+               'cpmd2coords': 'Convert the MIMIC/ATOMS section of CPMD input file to a pdb/gro file'}
+    
+    subprogram_help = {'getmpt': "\n-top\n\tInput Gromacs topology file\n"
+                       "-mpt\n\tOutput MiMiCPy topology file\n"
+                       "\nOptional arguments:\n"
+                       "\n-nonstd\n\tNon-standard residues list as text file\n"
+                       "\n-pdb\n\tpdb file to read non-standard residue elements from"
+                       "\n\tIt must have the element column filled for those residues!"
+                       "\n-itp\n\titp file to read non-standard residue atom types from"
+                       "\n-reslist\n\tList of nonstandard residues to read from pdb/itp files\n"
+                       "\nThe last three options must be given together\n",
+            'prepqm': "\nInput options:\n\n"
+                  "-top\n\tGromacs topology file\n"
+                  "-mpt\n\tMiMiCPy topology file\n"
+                  "\nOnly one of the above need to be specified\n\n"
+                  "-gro\n\tGromacs coordinate file\n"
+                  "\nOutput options:\n\n"
+                  "-cpmd\n\tCPMD input script name\n"
+                  "-ndx\n\tGromacs index file name\n",
+            'cpmd2coords': "\nSorry this subprogram is not implmented yet!\n"}
+    
+    def __init__(self):
+        self.program = sys.argv[0]
+        
+        if len(sys.argv) == 1:
+            self.help()
+        else:
+            self.subprogram = sys.argv[1]
+        
+        if self.subprogram not in self.subprograms.keys():
+            self.help('Invalid subprogram!')
+        
+        args = [i for i in sys.argv[2::2]]
+        vals = [i for i in sys.argv[3::2]]
+        
+        if args == [] or args == ['-help'] or args == ['-h']:
+            print(f"mimicpy {self.subprogram}: {self.subprograms[self.subprogram]}")
+            print(self.subprogram_help[self.subprogram])
+            sys.exit(0)
+        else:
+            print(f"MiMiCPy CLI Tool Requested: {self.subprogram}\n")
+        
+        for k,v in zip(args, vals):
+            setattr(self, k[1:], v)
+    
+    def __getattr__(self, key):
+        if key not in self.__dict__:
+            return None
+        
+    def help(self, message='\t\tVersion 1.0'):
+        
+        print(f"\n{message}\n\n"
+              "The following subprograms can be used:\n")
+        
+        for k,v in self.subprograms.items():
+            print(f"\no {k}:\n\t{v}")
+              
+        print(f"\nFormat:\n\t{self.program} <subprogram> <options for subprogram>\n")
+        sys.exit(0)
 
-def interact():
+def checkargs(args):
+    ret = 0
+    for k,v in args.items():
+        if v is None:
+            print(f"\n-{k} option should be specified!")
+            ret += 1
+    
+    if ret:
+        print(f'\nError in arguments passed. Exiting..\n')
+        sys.exit(0)
+
+def prepqm(qm, cpmd):
     command = input('Please enter the selection below. Type help to get help message.\n>  ')
     command = command.split()
     prefix = command[0].lower()
+    rest = " ".join(command[1:])
     if prefix == 'q'or prefix == 'quit':
+        try:
+            inp = qm.getInp(None)
+            with open(cpmd, 'w') as f: f.write(str(inp))
+        except mimicpy.utils.errors.MiMiCPyError:
+            pass
         return False
     elif prefix == 'add':
+        try:
+            qm.add(rest)
+        except mimicpy.utils.errors.SelectionError as e:
+            print(e, end='\n\n')
         return True
     elif prefix == 'del':
+        try:
+            qm.delete(rest)
+        except mimicpy.utils.errors.SelectionError as e:
+            print(e, end='\n\n')
         return True
     elif prefix == 'clear':
+        qm.clear()
         return True
     elif prefix == 'help' or prefix == 'h':
         print("Following commands are understood:\n\n"
-              "- add <selection>\n\tAdd atoms (given by the selection) to the QM region\n\n"
-              "- del <selection>\n\tDelete atoms (given by selection) from the QM region\n\n"
-              "- clear\n\tClear all atoms from the QM region to start over\n\n"
-              "- quit or q\n\tGenerate the CPMD input and Gromacs index files from selected atoms, and quit.\n\n"
-              "- help or h\n\tShow this help message.\n\n"
+              "o add <selection>\n\tAdd atoms (given by the selection) to the QM region\n\n"
+              "o del <selection>\n\tDelete atoms (given by selection) from the QM region\n\n"
+              "o clear\n\tClear all atoms from the QM region to start over\n\n"
+              "o quit or q\n\tGenerate the CPMD input and Gromacs index files from selected atoms, and quit.\n\n"
+              "o help or h\n\tShow this help message.\n\n"
               "A keyboard interrupt will cause an immediate termination. "
-              "Also, for more information on the selection langauge please refer to the docs.\n")
+              "For more information on the selection langauge please refer to the docs.\n")
     else:
         print("Command not understood! Type help to get a list of accepted commands.\n")
         return True
 
+def getmpt(topol, mpt, nonstd, reslist, pdb, itp):
+    print("Parsing topology..")
+    
+    mm = mimicpy.prepare.MM(savestatus=False, status = empty_status)
+    
+    if nonstd:
+        nonstd_atm = {}
+        with open(nonstd, 'r') as f:
+            for d in f.read().splitlines():
+                try:
+                    k,v = d.split()
+                except ValueError:
+                    print("Nonstandard residue file not in the correct format!\n")
+                    sys.exit(0)
+                nonstd_atm[k] = v
+        mm.nonstd_atm_types = nonstd_atm
+    elif reslist or pdb or itp:
+        checkargs({'reslist': reslist, 'pdb': pdb, 'itp': itp})
+        resname = []
+        with open(reslist, 'r') as f:
+            resname = f.read().splitlines()
+            loader = Loader('Reading coordinates')
+            mm.addLig(pdb, itp, buff=1000, *resname)
+            loader.close()
+    
+    return mm.getMPT(topol, mpt, guess_elems=True)
+
 if __name__ == '__main__':
     
+    print('\n\t***MiMiCPy CLI Tools****\n')
+    
     parser = MiMiCPyParser()
-    parser.add_argument("subprogram", help="Subprogram to be called", type=str)
     
-    args = parser.parse_args()
+    if parser.subprogram == 'getmpt':
+        checkargs({'mpt': parser.mpt, 'top': parser.top})
+        getmpt(parser.top, parser.mpt, parser.nonstd, parser.reslist, parser.pdb, parser.itp)
+        print("MPT succesfully prepared..\n")
+        
+    elif parser.subprogram == 'prepqm':
+        
+        if parser.mpt is not None:
+            mpt = parser.mpt
+        elif parser.top is not None:
+            mpt = getmpt(parser.top, None)
+        else:
+            print("Either -top or -mpt must be specified as an input file\n")
+            sys.exit(0)
+            
+        checkargs({'gro': parser.gro, 'cpmd': parser.cpmd, 'ndx': parser.ndx})
+            
+        print("Preparing QM region..")
+        
+        loader = Loader('Reading topology and coordinates')
+        qm = mimicpy.prepare.QM(mpt=mpt, gro=parser.gro, status = empty_status)
+        loader.close()
+        
+        qm.index = parser.ndx
+        qm.savestatus = False
     
-    if args.subprogram != 'prepqm':
-        sys.exit(0)
-    while True:
-        try:
-            ret = interact()
-        except (KeyboardInterrupt, EOFError):
-            print("\nExiting without saving..")
-            break
-        if ret == False: break
+        while True:
+            try:
+                ret = prepqm(qm, parser.cpmd)
+            except (KeyboardInterrupt, EOFError):
+                print("\nExiting without saving..")
+                ret = False
+                
+            if ret == False:
+                print('')
+                break
+    elif parser.subprogram == 'cpmd2coords':
+        # TO DO
+        pass

--- a/mimicpy/cmdline.py
+++ b/mimicpy/cmdline.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
         if parser.mpt is not None:
             mpt = parser.mpt
         elif parser.top is not None:
-            mpt = getmpt(parser.top, None)
+            mpt = getmpt(parser.top, None, None, None, None, None)
         else:
             print("Either -top or -mpt must be specified as an input file\n")
             sys.exit(0)

--- a/mimicpy/core/_qmhelper.py
+++ b/mimicpy/core/_qmhelper.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from ..scripts import cpmd
 
 def _cleanqdf(qdf):
-    columns = mpt.columns       
+    columns = mpt.columns.copy() # copy it otherwise original gets edited    
     columns.extend(['x','y','z'])
     lst = [l for l in qdf.columns if l not in columns]
     return qdf.drop(lst, axis=1)

--- a/mimicpy/core/_qmhelper.py
+++ b/mimicpy/core/_qmhelper.py
@@ -7,14 +7,14 @@ pptop() and getOverlaps_Atoms() adapted from the prepare_qmmm python script by V
 
 """
 
-from ..parsers.top_reader import ITPParser
+from ..parsers import mpt
 from ..utils.constants import bohr_rad
 from ..scripts.cpmd import Atom
 from collections import OrderedDict 
 from ..scripts import cpmd
 
 def _cleanqdf(qdf):
-    columns = ITPParser.columns       
+    columns = mpt.columns       
     columns.extend(['x','y','z'])
     lst = [l for l in qdf.columns if l not in columns]
     return qdf.drop(lst, axis=1)

--- a/mimicpy/core/_qmhelper.py
+++ b/mimicpy/core/_qmhelper.py
@@ -57,7 +57,7 @@ def getOverlaps_Atoms(qmatoms, inp):
         
         out += f"2 {idx} 1 {i + 1}\n" # overlap section string
         
-        if link: elem += '*'
+        if link: elem += '*' # append astericks to link atoms, so they are added as normal elem dict value
         
         if elem not in inp.atoms.keys(): # if new element is found
             # init a new Atom() for that element key

--- a/mimicpy/core/base.py
+++ b/mimicpy/core/base.py
@@ -38,7 +38,7 @@ class BaseHandle(ABC):
         self.gmxlog = LogString() # log string of standard ouput from all gmx commands
         
         # init logger with gmx log string, and notes redirected to stderr
-        self.logger = Logger(gmxlog=self.log, gmxnotes=sys.stderr)
+        self.logger = Logger(gmxlog=self.gmxlog, gmxnotes=sys.stderr)
         self.__current_cmd = 'gmx'
         
     ###Setting/getting current file/folder in status file
@@ -47,9 +47,14 @@ class BaseHandle(ABC):
     def setcurrent(self, dirc=None, key='run'):
         """Add new directory to _status dict"""
         
+        if not self.savestatus: return
+        
         if dirc == None: # if the argument is None add self.dir
             # meant for prepare classes
             dirc = self.dir
+        
+        if dirc.strip() == '': return
+        
         _global.host.mkdir(dirc)
         if key == 'prepMM' or key == 'prepQM': # add the correct key
             self._status[key] = dirc
@@ -162,7 +167,7 @@ class BaseHandle(ABC):
    
     @staticmethod
     def __readstatus():
-       if _global.host.fileExists(status_file): return None
+       if not _global.host.fileExists(status_file): return None
         
        _global.logger.write('debug', f"Loading status from {status_file}..")
        txt = _global.host.read(status_file)

--- a/mimicpy/core/base.py
+++ b/mimicpy/core/base.py
@@ -12,25 +12,49 @@ from .._global import _Global as _global
 from ..utils.errors import GromacsError, MiMiCPyError, EnvNotSetError
 from ..utils.logger import Logger, LogString
 import sys
+from abc import ABC, abstractmethod
 
-class BaseHandle:
+status_file = '_status.yaml'
+
+class BaseHandle(ABC):
     """
     Contains functions/variables common to all handles:
         prepare.MM, prepare.QM, simulate.MD, simulate.MiMiC
     All handles inherit from this class
-    
+    Mainly manages the status variable, and running gmx/cpmd command
     """
     
+    @abstractmethod
     def __init__(self, status=None):
         """Init status and log string"""
         self.savestatus = True
-        if not status:
-            status = {'prepMM': '', 'prepQM': '', 'run': ['']}
-        self._status = status # init _status
-        self.log = LogString() # log string of standard ouput from all gmx commands
+        
+        if not status: # if status passed is none, read from yaml
+            status = BaseHandle.__readstatus()
+            if not status: # if that too is none, create new status variable
+                status = {'prepMM': '', 'prepQM': '', 'run': ['']}
+        
+        self._status = status # set _status
+        self.gmxlog = LogString() # log string of standard ouput from all gmx commands
+        
         # init logger with gmx log string, and notes redirected to stderr
-        self.__logger = Logger(log=self.log, notes=sys.stderr)
+        self.logger = Logger(gmxlog=self.log, gmxnotes=sys.stderr)
         self.__current_cmd = 'gmx'
+        
+    ###Setting/getting current file/folder in status file
+    ##
+    ##   
+    def setcurrent(self, dirc=None, key='run'):
+        """Add new directory to _status dict"""
+        
+        if dirc == None: # if the argument is None add self.dir
+            # meant for prepare classes
+            dirc = self.dir
+        _global.host.mkdir(dirc)
+        if key == 'prepMM' or key == 'prepQM': # add the correct key
+            self._status[key] = dirc
+        elif dirc not in self._status['run']: # add to run list
+            self._status['run'].append(dirc)
     
     def getcurrent(self, ext, level=False, exp=True):
         """Find the latest file with extnestion ext using _status"""
@@ -105,7 +129,13 @@ class BaseHandle:
         if dirc.strip() != '': dirc += '/'
             
         return dirc+lst[0] # return with the directory
+    ##
+    ##
+    #####END
     
+    #### Methods dealing with loading from/writing to status file
+    ##
+    ##
     def getStatus(self): return self._status
     
     @classmethod
@@ -119,31 +149,32 @@ class BaseHandle:
     def toYaml(self):
         """Save _status to yaml"""
         if not self.savestatus: return
-        _global.logger.write('debug', f"Saving status to _status.yaml..")
+        _global.logger.write('debug', f"Saving status to {status_file}..")
         y = yaml.dump(self._status)
-        _global.host.write(y, '_status.yaml')
+        _global.host.write(y, status_file)
     
     @classmethod
     def fromYaml(cls, *args, **kwargs):
-       """Transfer _status from _status.yaml to new handle"""
-       _global.logger.write('debug', f"Loading status from _status.yaml..")
-       txt = _global.host.read('_status.yaml')
-       _status = yaml.safe_load(txt)
-       return cls(status=_status, *args, **kwargs)
+       """Transfer _status from status file to new handle"""
+       _status = BaseHandle.__readstatus()
+       if _status is None: _global.logger.write('warning', f"{status_file} does not exist, skipping..")
+       return cls(status=BaseHandle.__readstatus(), *args, **kwargs)
    
-    def setcurrent(self, dirc=None, key='run'):
-        """Add new directory to _status dict"""
+    @staticmethod
+    def __readstatus():
+       if _global.host.fileExists(status_file): return None
         
-        if dirc == None: # if the argument is None add self.dir
-            # meant for prepare classes
-            dirc = self.dir
-        _global.host.mkdir(dirc)
-        if key == 'prepMM' or key == 'prepQM': # add the correct key
-            self._status[key] = dirc
-        elif dirc not in self._status['run']: # add to run list
-            self._status['run'].append(dirc)
+       _global.logger.write('debug', f"Loading status from {status_file}..")
+       txt = _global.host.read(status_file)
+       return yaml.safe_load(txt)
+    ##
+    ##
+    ###END
     
-    def _gmxhook(self, cmd, text):
+    ###Methods dealing with running gromacs/cpmd through shell
+    ##
+    ##
+    def __gmxhook(self, cmd, text):
         """
         Function called by _global.host eveytime a gmx command is executed
         Used to parse gmx ouput and check for errors/notes/warnings
@@ -152,15 +183,15 @@ class BaseHandle:
             raise GromacsError(cmd, text)
         
         # write log
-        self.__logger.write('log', f"==>Command Run: {cmd}\n")
-        self.__logger.write('log', text)
+        self.logger.write('gmxlog', f"==>Command Run: {cmd}\n")
+        self.logger.write('gmxlog', text)
         
         self.__gmxerrhdnl(cmd, text) # check for errors
         
         notes = BaseHandle.__notes(self.__current_cmd, text) # get notes/warnings
         
         if not notes.isspace() and notes.strip() != '': # write notes
-            self.__logger.write('notes', notes)
+            self.logger.write('gmxnotes', notes)
     
     @staticmethod
     def __gmxerrhdnl(gmx_cmd, text, dont_raise=False):
@@ -267,8 +298,8 @@ class BaseHandle:
         _global.logger.write('debug', f"Running {cmd}..")
         
         self.current_gmx = cmd
-        if mdrun: _global.host.runbg(cmd, hook=self._gmxhook, dirc=dirc) # runbg for mdrun
-        else: _global.host.run(cmd, stdin=stdin, hook=self._gmxhook, dirc=dirc) # run for everything else
+        if mdrun: _global.host.runbg(cmd, hook=self.__gmxhook, dirc=dirc) # runbg for mdrun
+        else: _global.host.run(cmd, stdin=stdin, hook=self.__gmxhook, dirc=dirc) # run for everything else
     
     def grompp(self, mdp, new, **kwargs):
         """
@@ -318,7 +349,7 @@ class BaseHandle:
           
     def cpmd(self, inp, out, onlycmd=False, dirc=''):
         """
-        Function to execute gmx commands in "pythonic" way
+        Function to execute cpmd command in "pythonic" way
         e.g., to execute cpmd cpmd.in path/to/pp > cpmd.oput
         call cpmd('cpmd.in', 'cpmd.out')
         Make sure cpmd_pp is set in _Global before that!
@@ -339,3 +370,6 @@ class BaseHandle:
         
         _global.logger.write('debug', "Running {cmd}..")
         _global.host.runbg(cmd, dirc=dirc)
+    ##
+    ##
+    ###END

--- a/mimicpy/core/prepare.py
+++ b/mimicpy/core/prepare.py
@@ -126,7 +126,7 @@ class QM(BaseHandle):
     
     def delete(self, selection=None):
         """Delete from QM region using selection langauage"""
-        qdf = QM._cleanqdf( self.selector.select(selection) )
+        qdf = _qmhelper._cleanqdf( self.selector.select(selection) )
         # drop selection, ignore pandas errors to disregard extra residues selected that are not present in self.qmatoms
         self.qmatoms = self.qmatoms.drop(qdf.index, errors='ignore')
     
@@ -180,7 +180,7 @@ class QM(BaseHandle):
             if not mdp.hasparam('dt'): mdp.dt = dt # default value, if not present in mdp
             else: dt = mdp.dt
             
-            self.grompp(mdp, self.mimic, gro=self.gro, n=self.index, dirc=self.dirc)
+            self.grompp(mdp, self.mimic, gro=self.gro, n=self.index, dirc=self.dir)
             
         # sort by link column first, then element symbol
         # ensures that all link atoms are last, and all elements are bunched together

--- a/mimicpy/core/selector.py
+++ b/mimicpy/core/selector.py
@@ -1,8 +1,9 @@
-from ..shell import _local
 from .._global import _Global as gbl
-from ..parsers import gro
+from ..parsers import gro, parser
 import xmlrpc.client as xmlrpclib
 import pandas as pd
+import tempfile
+from collections import defaultdict
 
 class Selector:
     def __init__(self, lines=500):
@@ -67,55 +68,63 @@ class Selector:
         return eval(ev) # evaluate string and return the dataframe
 
 class PyMOL(Selector):
+    """PyMOL selector to process a PyMOL selection and combine it with an MPT
+    Can be used by connecting to PyMOL using xmlrpc or by executing in the PyMOL interpreter
+    """
     
-    def _hook(self, out):
-        if 'xml-rpc server running on host' in out:
-            
-            self.port = out.split()[-1]
-            self.host = out.split()[-3].replace(',', '')
-            
-            return True
-        else:
-            return False
-    
-    def __init__(self, launch=True, host='localhost', port=9123, load=True, forcelocal=False, downloadpath='temp.gro'):
-        if launch:
-            _local.runbg('pymol -R', hook=self._hook)
-        else:
-            self.host = host
-            self.port = port
+    def __init__(self, cmd=None, url='http://localhost:9123', load=True, forcelocal=False, lines=500):
         
-        try:
-            self.cmd = xmlrpclib.ServerProxy(f'http://{host}:{port}')
-        except:
-            print('Cannot connect to PyMol at host {host} and port {port}!')
+        if cmd is None:
+            self.cmd = xmlrpclib.ServerProxy(url)
+        else:
+            self.cmd = cmd
         
         self.load = load
         self.forcelocal = forcelocal
-        self.downloadpath = downloadpath
+        self.lines = lines
     
     def load(self, mpt, gro):
-        if not gbl.host.isLocal() and not self.forceLocal:
-            gbl.host.sftp.get(gro, self.downloadpath)
-            gro = self.downloadpath
+        if not gbl.host.isLocal() and self.forceLocal:
+            # if remote and want to run pymol locally, download gro to temp file
+            temp = tempfile.NamedTemporaryFile(prefix='mimicpy_temp_', suffix=".gro")
+            gro_parser = parser.Parser(gro, self.lines)
+            for i in gro_parser: temp.write(i.encode('utf-8'))
+            gro_parser.close()
+            gro = temp.name
         
         self.cmd.load(gro)
         self.mpt = mpt
         
         return gro.getBox(gro)
     
+    def __sele2df(self, sele):
+        if isinstance(sele, dict):
+            # sele is dict if using xmlrpc
+            # atom key of dict has all we need
+            df_dict = sele['atom']
+        else:
+            # sele will br chempy.models.Indexed object if using from pymol
+            # sele.atom is is a list of chempy.Atom objects, each atom has id, symbol, etc.
+            df_dict = defaultdict(list)
+            params_to_get = ['id', 'symbol', 'name', 'resn', 'resi_number', 'coord']
+            for a in sele.atom:
+                for i in params_to_get:
+                    df_dict[i] = getattr(a, i)
+        
+        df = pd.DataFrame(df_dict)
+        # extract coordinates and covert from ang to nm
+        x,y,z = list(zip(*df[['coord']].apply(lambda x: [i/10 for i in x[0]], axis=1)))
+        df.insert(2, "x", x, True) 
+        df.insert(2, "y", y, True) 
+        df.insert(2, "z", z, True)
+        df = df.drop(['coord'], axis=1)
+        df = df.rename(columns={"name": "pm_name", "symbol": "pm_symbol", "resn": "pm_resn",\
+                               "resi_number": "pm_resi_number"})
+    
     def select(self, selection=None):
         if selection is None: selection = 'sele'
-        ids = self.cmd.get_model(selection, 1)
-        pymol_sele = pd.DataFrame(ids['atom'])
-        # extract coordinates and covert from ang to nm
-        x,y,z = list(zip(*pymol_sele[['coord']].apply(lambda x: [i/10 for i in x[0]], axis=1)))
-        pymol_sele.insert(2, "x", x, True) 
-        pymol_sele.insert(2, "y", y, True) 
-        pymol_sele.insert(2, "z", z, True)
-        pymol_sele = pymol_sele.drop(['coord'], axis=1)
-        pymol_sele = pymol_sele.rename(columns={"name": "pm_name", "symbol": "pm_symbol", "resn": "pm_resn",\
-                               "resi_number": "pm_resi_number"})
+        sele_return = self.cmd.get_model(selection, 1)
+        pymol_sele = self.__sele2df(sele_return)
     
         mpt_sele = self.mpt.selectByIDs(pymol_sele['id'])
         

--- a/mimicpy/parsers/mpt.py
+++ b/mimicpy/parsers/mpt.py
@@ -50,10 +50,10 @@ class MPT:
         
         packer = xdrlib.Packer()
         
-        mol_names, no = list(zip(*self.mol_list)) # unzip list of tuples to get mol_name and nums
+        mol_names, no = list(zip(*self.__mol_list)) # unzip list of tuples to get mol_name and nums
         pack_strlist(packer, mol_names) #pack mol names as string list
         packer.pack_list(no, packer.pack_int) #pack num of mols as list of ints
-        pack_topol_dict(packer, self.topol_dict) #pack topol dict object
+        pack_topol_dict(packer, self.__topol_dict) #pack topol dict object
         gbl.host.write(packer.get_buffer(), fname, asbytes=True)
     
     @classmethod

--- a/mimicpy/parsers/top_reader.py
+++ b/mimicpy/parsers/top_reader.py
@@ -18,7 +18,7 @@ def getSection(section, txt):
     # i.e., no comments or double new lines
     
     # find text b/w [ section ] and either [ or # (for #if, etc.) or EOF
-    reg = re.compile(fr"\[\s*{section}\s*\]\n((?:.+\n)+?)(?:$|\[|#)", re.MULTILINE)
+    reg = re.compile(fr"\[\s*{section}\s*\]\n((?:.+\n)+?)\s*(?:$|\[|#)", re.MULTILINE)
     r = reg.findall(txt)
     return r
 
@@ -131,7 +131,6 @@ class ITPParser:
             itp_text = self.read(file_name)
         
         itp_text = cleanText(itp_text)
-        
         mol_section = getSection('moleculetype', itp_text)
         atom_section = getSection('atoms', itp_text)
         

--- a/mimicpy/parsers/top_reader.py
+++ b/mimicpy/parsers/top_reader.py
@@ -96,7 +96,7 @@ def atomtypes(itp_file, buff):
 
 class ITPParser:    
     
-    columns = ['number', 'type', 'resid', 'resname', 'name', 'charge','element',	'mass']
+    columns = ['number', 'type', 'resid', 'resname', 'name', 'charge', 'element', 'mass']
     dfs = []
     mols = []
 

--- a/mimicpy/parsers/top_reader.py
+++ b/mimicpy/parsers/top_reader.py
@@ -180,7 +180,7 @@ class ITPParser:
                 
                 if mass_int <= 0:
                     raise ParserError(file=file_name, ftype="topolgy", \
-                                     extra=(f"Cannot determine atomic symbol for atom ID {nr} and name {name} in residue {res} as mass"
+                        extra=(f"Cannot guess atomic symbol for atom with name {name} and type {_type} in residue {res} as mass"
                                              "information is not available from the force field"))
                 # guess atomic no from mass
                 # works well if no isotopes present
@@ -189,10 +189,11 @@ class ITPParser:
                 elif mass_int<36: elem = element_names[mass_int//2 - 1] # He to Cl
                 else: elem = name.title() # from Ar onwards, assume name same as symbol, case insensitive
                 
-                gbl.logger.write('warning', (f"Guessing atomic symbol for atom id {nr} and name {name} in residue {res} as {elem}..") )
+                gbl.logger.write('warning', (f"Guessing atomic symbol for atom with name {name} and type {_type} "
+                                             f"in residue {res} as {elem}..") )
             else:
                 raise ParserError(file=file_name, ftype="topology", \
-                                     extra=f"Cannot determine atomic symbol for atom ID {nr} and name {name} in residue {res}")
+                            extra=f"Cannot determine atomic symbol for atom with name {name} and type {_type} in residue {res}")
             
             df_[c[6]].append(elem)
             df_[c[7]].append(mass)

--- a/mimicpy/parsers/top_reader.py
+++ b/mimicpy/parsers/top_reader.py
@@ -144,6 +144,8 @@ class ITPParser:
     def _parseatoms(self, txt, file_name):
         
         df_ = {k:[] for k in self.columns}
+        prev_resn = 1
+        resid = 1
         
         for line in txt.splitlines():
             
@@ -159,7 +161,13 @@ class ITPParser:
             c = self.columns
             df_[c[0]].append(int(nr))
             df_[c[1]].append(_type)
-            df_[c[2]].append(int(resnr))
+            
+            if resnr != prev_resn:
+                resid += 1
+                resnr = prev_resn
+            
+            df_[c[2]].append(resid)
+            
             df_[c[3]].append(res)
             df_[c[4]].append(name)
             df_[c[5]].append(float(q))

--- a/mimicpy/parsers/top_reader.py
+++ b/mimicpy/parsers/top_reader.py
@@ -85,7 +85,7 @@ def atomtypes(itp_file, buff):
         e = line.split()[0] # first val is atom type
         _n = line.split()[1]
          
-        if not _n.isnumeric():
+        if not _n.isnumeric(): # better do a proper string comparison (no points, only three digits)
             # should raise an exception here
             continue
         else: n = int(_n)-1 # second is element no.
@@ -106,11 +106,11 @@ class ITPParser:
         ITPParser.mols = []
         ITPParser.dfs = []
 
-    def __init__(self, mols_to_read, atm_types_to_symb, buff, guess):
+    def __init__(self, mols_to_read, atm_types_to_symb, buff, guess_elements):
         self.mols_to_read = mols_to_read
         self.atm_types_to_symb = atm_types_to_symb
         self.buff = buff
-        self.guess = guess
+        self.guess_elements = guess_elements
     
     def read(self, file_name):
         file = Parser(file_name, self.buff)
@@ -150,8 +150,6 @@ class ITPParser:
     def _parseatoms(self, txt, file_name):
         
         df_ = {k:[] for k in self.columns}
-        prev_resn = 1
-        resid = 1
         
         for i, line in enumerate(txt.splitlines()):
             
@@ -167,13 +165,7 @@ class ITPParser:
             c = self.columns
             df_[c[0]].append(int(nr))
             df_[c[1]].append(_type)
-            
-            if resnr != prev_resn:
-                resid += 1
-                resnr = prev_resn
-            
-            df_[c[2]].append(resid)
-            
+            df_[c[2]].append(int(resnr))
             df_[c[3]].append(res)
             df_[c[4]].append(name)
             df_[c[5]].append(float(q))
@@ -181,7 +173,7 @@ class ITPParser:
             
             if _type in self.atm_types_to_symb:
                 elem = self.atm_types_to_symb[_type]
-            elif self.guess:
+            elif self.guess_elements:
                 mass_int = int(mass)
                 
                 if mass_int <= 0:

--- a/mimicpy/scripts/base.py
+++ b/mimicpy/scripts/base.py
@@ -10,9 +10,13 @@ of assining parameters with the dot operator.
 
 from collections import OrderedDict 
 from ..utils.errors import ScriptError
+from .._global import _Global as gbl
+from abc import ABC, abstractmethod
 
-class Script(object):
+class Script(ABC):
+    
     def __init__(self, **kwargs):
+        # create an internal orderdict to store all params and retain order
         super().__setattr__('__orddict__', OrderedDict())
         
         for key, value in kwargs.items():
@@ -20,25 +24,49 @@ class Script(object):
             
     def __setattr__(self, key, value):
         if key.startswith('_') or key == 'hasparams' or key == 'params':
+            # protected/private attrs and hasparams() and params() are stored in the normal __dict__
             self.__dict__[key] = value
         else:
+            # rest are script params and stored in __orddict__
             self.__orddict__[key] = value
         
     def __getattr__(self, key):
         if key.startswith('_') or key == 'hasparams' or key == 'params':
+            # if asking fro protected/private attrs, hasparams() or params() look in the normal __dict__
             return self.__getattribute__('__dict__')[key]
         else:
+            # else look in __orddict__
             if key not in self.__getattribute__('__orddict__'):
-                raise ScriptError(key)
+                raise ScriptError(key) # raise param not found error
                 
             return self.__getattribute__('__orddict__')[key]
     
     def hasparam(self, key):
+        """Convienience function to check if script has a param"""
         if key in self.__orddict__:
             return True
         else:
             return False
     
-    def params(self): return self.__orddict__
+    def params(self):
+        """Convienience function to return dict of params"""
+        return self.__orddict__
     
-    def __repr__(self): return self.__str__()
+    def __repr__(self):
+        """For printty printing in Jupyter"""
+        return self.__str__()
+    
+    @classmethod    
+    def fromFile(cls, script):
+        return cls.fromText(gbl.host.read(script))
+                
+    @classmethod
+    @abstractmethod  
+    def fromText(cls, text):
+        # should be defined in children
+        pass
+    
+    @abstractmethod  
+    def __str__(self):
+        # should be defined in children
+        pass

--- a/mimicpy/scripts/cpmd.py
+++ b/mimicpy/scripts/cpmd.py
@@ -29,6 +29,11 @@ class Section(Script):
         
         return val
     
+    # empty func to satisfy base class abstract method
+    @classmethod
+    def fromText(cls, text):
+         return cls()
+    
 class Atom:
     def __init__(self, coords=[], lmax='s', pp='MT_BLYP', labels=''):
         self.coords = coords
@@ -69,6 +74,7 @@ class Input(Script):
             elif d.upper() == 'ATOMS':
                 atoms = '\n&ATOMS\n'
                 for k, v in getattr(self, d).items():
+                    # link atoms are marked with astericks, like C*, in prepare.QM
                     atoms += f'*{k.replace("*", "")}{str(v)}'
                 atoms += '&END\n'
             else:
@@ -76,3 +82,13 @@ class Input(Script):
                 val += f"\n&{d.upper()}\n{v}&END\n"
         
         return info+val+atoms
+    
+    @classmethod
+    def fromText(cls, text):
+         # TO DO
+         return cls()
+     
+    def getCoords(self, mpt, out):
+        # convert cpmd atom/mimic section to pdb/gro using mpt data
+        # TO DO
+        pass

--- a/mimicpy/scripts/mdp.py
+++ b/mimicpy/scripts/mdp.py
@@ -9,7 +9,6 @@ Gromacs MDP script
 """
 
 from .base import Script
-from .._global import _Global as gbl
 from ..utils.errors import ParserError
 
 class MDP(Script):
@@ -42,10 +41,6 @@ class MDP(Script):
         return val
     
     @classmethod
-    def fromFile(cls, script):
-        return cls.fromText(gbl.host.read(script))
-    
-    @classmethod
     def fromText(cls, script):
         kwargs = {}
         for i, line in enumerate(script.splitlines()):
@@ -60,8 +55,8 @@ class MDP(Script):
         return cls(**kwargs)                  
     
     @classmethod
-    def defaultGenion(cls):
-        return cls(name = 'Genion',
+    def defaultEM(cls):
+        return cls(name = 'Minim',
                    integrator = "steep",  # Algorithm (steep = steepest descent minimization)
                    emtol = 1000.0, # Stop minimization when the maximum force < 1000.0 kJ/mol/nm
                    emstep = 0.01,  # Minimization step size
@@ -70,19 +65,12 @@ class MDP(Script):
                    nstlist = 10, # Frequency to update the neighbor list and long range forces
                    cutoff_scheme = "Verlet", # Buffered neighbor searching 
                    ns_type = "grid", # Method to determine neighbor list (simple, grid)
-                   coulombtype = "cutoff", #Treatment of long range electrostatic interactions
+                   coulombtype = "PME", #Treatment of long range electrostatic interactions
                    rcoulomb = 1.0,# Short-range electrostatic cut-off
                    rvdw = 1.0, # Short-range Van der Waals cut-off
                    pbc = 'xyz'
                    )
         
-    @classmethod
-    def defaultEM(cls):
-        em = cls.defaultGenion()
-        em.name = 'Minim'
-        em.coulombtype = "PME"
-        return em
-    
     @classmethod
     def defaultNVT(cls):
         return cls(name = 'NVT', 

--- a/mimicpy/scripts/slurm.py
+++ b/mimicpy/scripts/slurm.py
@@ -9,7 +9,6 @@ Slurm jobscripts
 """
 
 from .base import Script
-from .._global import _Global as _global
 
 class Slurm(Script):
     def __init__(self, name='jobscript', shebang='/bin/bash', cmd_hdr='srun', cmds = [], **kwargs):
@@ -27,11 +26,7 @@ class Slurm(Script):
         if name: self._name = name
         if shebang: self._shebang = shebang
         if cmd_hdr: self._cmd_hdr = cmd_hdr
-    
-    @classmethod    
-    def fromFile(cls, script):
-        return cls.fromText(_global.host.read(script))
-                
+        
     @classmethod    
     def fromText(cls, text):
         shebang = "/usr/sh"

--- a/mimicpy/shell/_local.py
+++ b/mimicpy/shell/_local.py
@@ -34,9 +34,12 @@ def run(cmd, shell_ex, remove_from_out, stdin=None, hook=None):
     
     return out
 
-def runbg(self, cmd, shell_ex, remove_from_out, hook=None):
-    subprocess.Popen(cmd, shell=True, executable=shell_ex, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    # add communication till output not changes like remote
+def runbg(cmd, shell_ex, remove_from_out, hook=None):
+    out = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, universal_newlines=True)
+    
+    for stdout_line in iter(out.stdout.readline, ""):
+        if hook:
+            if hook(cmd, stdout_line): return
 
 def ls(dirc, file_eval, dir_eval):
         

--- a/mimicpy/shell/_remote.py
+++ b/mimicpy/shell/_remote.py
@@ -170,7 +170,8 @@ class _ShellBGRun:
                     
                 prev = self.stdout
                     
-                if hook: hook(cmd, text)
+                if hook:
+                    if hook(cmd, text): break
                 
             else: break
         

--- a/mimicpy/shell/shell.py
+++ b/mimicpy/shell/shell.py
@@ -14,16 +14,19 @@ import re
 from ..utils.errors import SlurmBatchError
 from ..utils.fstring import f
 from .._global import _Global as _gbl
+from abc import ABC, abstractmethod
 
-class Base():
+class Base(ABC):
     """
 
     Base shell class, contains methods common to both local and remote shell
+    Cannot be instantiated, depends on functions from local/remote
 
     """
     
+    @abstractmethod
     def __init__(self, directory,  *loaders):
-        """Init cwd and loaders"""
+        """ Init cwd and loaders """
         
         if directory.strip() == '':
             directory = '.'
@@ -66,6 +69,9 @@ class Base():
         if self.name == 'localhost': return True
         else: return False
     
+    @abstractmethod
+    def hndl(self): pass
+    
     def checkFile(self, file, throw=False):
         """ Check if file exists, for debugging """
         ret = self.fileExists(file)
@@ -81,7 +87,7 @@ class Base():
         with self.open(file, mode) as f:
             out = f.read()
             if not asbytes:
-                # sftp file objects, when read, return only bytes
+                # sftp file objects, when read, returns only bytes
                 # so need to decode it if self is remote
                 try:
                     return out.decode()

--- a/mimicpy/utils/errors.py
+++ b/mimicpy/utils/errors.py
@@ -10,6 +10,9 @@ used in the package
 class MiMiCPyError(Exception):
    """Generic exception from MiMiCPy"""
 
+class SelectionError(MiMiCPyError):
+    """Error in selecting atoms in MPT"""
+    
 class ParserError(MiMiCPyError):
     """
     Raised when a file could not be parsed


### PR DESCRIPTION
After the MPT format was changed, I went ahead and tried to fix the ResID problem. I made the following main changes in the way the selection language works:
- Before, the full dataframe had to be generated by getSystemTopology() so that the selection can be done using the easy to use pandas boolean. But, I found that such a large dataframe was taking too much memory and was not efficient. Memory estimation is a bit tricky with python, but it looked like for my system the dataframe was around 100 MB.
- So, now it stores each column of the dataframe as a list internally. Lists can be grown (appended to) faster than dataframes and numpy arrays, and take up much less memory.
- But, selecting (esp. multiple elements) is much faster with numpy. So, for the selection each of these lists is converted into a numpy arrays. The selection language is then, converted into something np.where() can understand instead of the pandas boolean.
- All lists are generated when the MPT() constructor is called (if only writing is to be done, mode='w' can be passed to not generated the lists and save time). ResID is its own list, and it has to be separately generated. It takes a bit longer than the other lists to generate. I have not found. a way to shorten this time. Anyways, the whole loading takes around 1.5 s on local machine and 2.5 s of remote machine so it should be fine.
- Also, a rudimentary version of the VMD selector has been added. I do not have a stable working version of VMD, so have not been able to test it out properly.

I've tried to put comments for clarity. We will discuss about this pull request anyway. Please go through this branch and test it well, only then we'll merge it.